### PR TITLE
fix db query

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -59,11 +59,24 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                 setSession(currentSession);
 
                 if (currentSession?.user?.email) {
-                    const { data: voterData } = await supabase
-                        .from("voters")
-                        .select("*")
-                        .eq("user_email", currentSession.user.email)
-                        .single();
+                    console.log(
+                        "Querying voter for email:",
+                        currentSession.user.email,
+                    );
+                    const { data: voterData, error: voterError } =
+                        await supabase
+                            .from("voters")
+                            .select("*")
+                            .eq("user_email", currentSession.user.email)
+                            .single();
+
+                    if (voterError) {
+                        console.error("Voter query error:", voterError);
+                        if (voterError.code !== "PGRST116") {
+                            // PGRST116は"No rows found"
+                            throw voterError;
+                        }
+                    }
 
                     if (voterData) {
                         setVoter(voterData);
@@ -94,11 +107,26 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
             setSession(session);
 
             if (session?.user?.email) {
-                const { data: voterData } = await supabase
+                console.log(
+                    "Auth state change - querying voter for email:",
+                    session.user.email,
+                );
+                const { data: voterData, error: voterError } = await supabase
                     .from("voters")
                     .select("*")
                     .eq("user_email", session.user.email)
                     .single();
+
+                if (voterError) {
+                    console.error("Auth state voter query error:", voterError);
+                    if (voterError.code !== "PGRST116") {
+                        // PGRST116は"No rows found"
+                        console.error(
+                            "Unexpected voter query error:",
+                            voterError,
+                        );
+                    }
+                }
 
                 if (voterData) {
                     setVoter(voterData);

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -52,7 +52,21 @@ if (useLocalDb || !supabaseUrl || supabaseUrl === "https://test.supabase.co") {
 
     const finalUrl = supabaseUrl || "https://test.supabase.co";
     const finalKey = supabaseAnonKey || "test-anon-key";
-    client = createClient<Database>(finalUrl, finalKey) as any;
+    client = createClient<Database>(finalUrl, finalKey, {
+        global: {
+            headers: {
+                Accept: "application/json",
+                "Content-Type": "application/json",
+            },
+        },
+        db: {
+            schema: "public",
+        },
+        auth: {
+            autoRefreshToken: true,
+            persistSession: true,
+        },
+    }) as any;
 }
 
 export const supabase = client;


### PR DESCRIPTION

⏺ 修正内容：

  1. Supabaseクライアント設定の改善：
    - 明示的なAccept/Content-Typeヘッダー
    - データベーススキーマの指定
    - 認証設定の最適化
  2. 詳細エラーログの追加：
    - クエリ実行時のメールアドレスをログ出力
    - エラー詳細情報の記録
    - 406エラーの原因特定に必要な情報を収集
  3. エラーハンドリングの改善：
    - PGRST116（No rows found）エラーを除外
    - 予期しないエラーの詳細ログ

  406エラーの原因として考えられるもの：
  1. Supabaseプロジェクトの設定問題
  2. メールアドレスの特殊文字処理
  3. CORS設定の問題
  4. Supabase APIキーの権限不足

  この修正でより詳細なエラー情報が得られ、406エラーの根本原因を特定できる
  はずです。