### PR TITLE
スマートフォン・タブレット対応: レスポンシブUI改善とハンバーガーメニュー実装

### DIFF
--- a/src/app/issue-vote/page.tsx
+++ b/src/app/issue-vote/page.tsx
@@ -4,6 +4,24 @@ import { useAuth } from "../../contexts/AuthContext";
 import { supabase } from "../../lib/supabaseClient";
 import type { Tables } from "../../types/supabase";
 
+// スマートフォン判定のカスタムフック
+const useIsMobile = () => {
+    const [isMobile, setIsMobile] = useState(false);
+
+    useEffect(() => {
+        const checkIfMobile = () => {
+            setIsMobile(window.innerWidth <= 480);
+        };
+
+        checkIfMobile();
+        window.addEventListener("resize", checkIfMobile);
+
+        return () => window.removeEventListener("resize", checkIfMobile);
+    }, []);
+
+    return isMobile;
+};
+
 type SortOption = "created_at_desc" | "id_asc";
 
 export default function IssueVotePageComponent() {
@@ -30,6 +48,7 @@ export default function IssueVotePageComponent() {
     const [searchError, setSearchError] = useState<string | null>(null);
     const navigate = useNavigate();
     const { voter, isAuthenticated, loading: authLoading } = useAuth();
+    const isMobile = useIsMobile();
 
     const ITEMS_PER_PAGE = 50;
     const [sortOption, setSortOption] = useState<SortOption>("created_at_desc");
@@ -433,6 +452,7 @@ export default function IssueVotePageComponent() {
         alignItems: "center",
         gap: "0.5rem",
         marginTop: "2rem",
+        flexWrap: "wrap" as const,
     };
 
     const pageButtonStyle = {
@@ -444,6 +464,11 @@ export default function IssueVotePageComponent() {
         cursor: "pointer",
         fontSize: "0.9rem",
         fontWeight: "500",
+        minWidth: "44px",
+        minHeight: "44px",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
     };
 
     const activePageButtonStyle = {
@@ -714,7 +739,7 @@ export default function IssueVotePageComponent() {
                                             : "pointer",
                                 }}
                             >
-                                ≪ 最初
+                                {isMobile ? "≪" : "≪ 最初"}
                             </button>
                             <button
                                 onClick={() =>
@@ -730,15 +755,20 @@ export default function IssueVotePageComponent() {
                                             : "pointer",
                                 }}
                             >
-                                前へ
+                                {isMobile ? "‹" : "前へ"}
                             </button>
 
                             {Array.from(
-                                { length: Math.min(5, totalPages) },
+                                {
+                                    length: Math.min(
+                                        isMobile ? 3 : 5,
+                                        totalPages,
+                                    ),
+                                },
                                 (_, i) => {
                                     const startPage = Math.max(
                                         1,
-                                        currentPage - 2,
+                                        currentPage - (isMobile ? 1 : 2),
                                     );
                                     const pageNum = startPage + i;
                                     if (pageNum > totalPages) return null;
@@ -778,7 +808,7 @@ export default function IssueVotePageComponent() {
                                             : "pointer",
                                 }}
                             >
-                                次へ
+                                {isMobile ? "›" : "次へ"}
                             </button>
                             <button
                                 onClick={() => setCurrentPage(totalPages)}
@@ -793,7 +823,7 @@ export default function IssueVotePageComponent() {
                                             : "pointer",
                                 }}
                             >
-                                最後 ≫
+                                {isMobile ? "≫" : "最後 ≫"}
                             </button>
                         </div>
                     )}
@@ -1083,22 +1113,35 @@ export default function IssueVotePageComponent() {
                                                 justifyContent: "space-between",
                                                 flexWrap: "wrap",
                                                 gap: "1rem",
+                                                ...(isMobile && {
+                                                    flexDirection: "column",
+                                                    alignItems: "stretch",
+                                                }),
                                             }}
                                         >
                                             <div
                                                 style={{
                                                     display: "flex",
                                                     gap: "0.5rem",
+                                                    ...(isMobile && {
+                                                        justifyContent:
+                                                            "center",
+                                                    }),
                                                 }}
                                             >
                                                 <button
-                                                    style={
-                                                        selectedVote ===
+                                                    style={{
+                                                        ...(selectedVote ===
                                                             "good" ||
                                                         existingVote === "good"
                                                             ? selectedGoodButtonStyle
-                                                            : goodButtonStyle
-                                                    }
+                                                            : goodButtonStyle),
+                                                        ...(isMobile && {
+                                                            fontSize: "1rem",
+                                                            padding:
+                                                                "0.6rem 1rem",
+                                                        }),
+                                                    }}
                                                     onClick={() =>
                                                         handleVoteSelect(
                                                             issue.issue_id,
@@ -1106,16 +1149,23 @@ export default function IssueVotePageComponent() {
                                                         )
                                                     }
                                                 >
-                                                    👍 Good
+                                                    {isMobile
+                                                        ? "👍"
+                                                        : "👍 Good"}
                                                 </button>
                                                 <button
-                                                    style={
-                                                        selectedVote ===
+                                                    style={{
+                                                        ...(selectedVote ===
                                                             "bad" ||
                                                         existingVote === "bad"
                                                             ? selectedBadButtonStyle
-                                                            : badButtonStyle
-                                                    }
+                                                            : badButtonStyle),
+                                                        ...(isMobile && {
+                                                            fontSize: "1rem",
+                                                            padding:
+                                                                "0.6rem 1rem",
+                                                        }),
+                                                    }}
                                                     onClick={() =>
                                                         handleVoteSelect(
                                                             issue.issue_id,
@@ -1123,7 +1173,7 @@ export default function IssueVotePageComponent() {
                                                         )
                                                     }
                                                 >
-                                                    👎 Bad
+                                                    {isMobile ? "👎" : "👎 Bad"}
                                                 </button>
                                             </div>
 
@@ -1144,6 +1194,11 @@ export default function IssueVotePageComponent() {
                                                         cursor: submitting
                                                             ? "not-allowed"
                                                             : "pointer",
+                                                        ...(isMobile && {
+                                                            fontSize: "0.9rem",
+                                                            padding:
+                                                                "0.7rem 1.5rem",
+                                                        }),
                                                     }}
                                                 >
                                                     {submitting
@@ -1166,9 +1221,17 @@ export default function IssueVotePageComponent() {
                                                     backgroundColor: "#24292e",
                                                     textDecoration: "none",
                                                     display: "inline-block",
+                                                    textAlign: "center",
+                                                    ...(isMobile && {
+                                                        fontSize: "0.9rem",
+                                                        padding:
+                                                            "0.7rem 1.5rem",
+                                                    }),
                                                 }}
                                             >
-                                                🔗 GitHubで開く
+                                                {isMobile
+                                                    ? "GitHub"
+                                                    : "🔗 GitHubで開く"}
                                             </a>
                                         </div>
                                     </div>
@@ -1189,7 +1252,7 @@ export default function IssueVotePageComponent() {
                                                 : "pointer",
                                     }}
                                 >
-                                    ≪ 最初
+                                    {isMobile ? "≪" : "≪ 最初"}
                                 </button>
                                 <button
                                     onClick={() =>
@@ -1207,15 +1270,20 @@ export default function IssueVotePageComponent() {
                                                 : "pointer",
                                     }}
                                 >
-                                    前へ
+                                    {isMobile ? "‹" : "前へ"}
                                 </button>
 
                                 {Array.from(
-                                    { length: Math.min(5, totalPages) },
+                                    {
+                                        length: Math.min(
+                                            isMobile ? 3 : 5,
+                                            totalPages,
+                                        ),
+                                    },
                                     (_, i) => {
                                         const startPage = Math.max(
                                             1,
-                                            currentPage - 2,
+                                            currentPage - (isMobile ? 1 : 2),
                                         );
                                         const pageNum = startPage + i;
                                         if (pageNum > totalPages) return null;
@@ -1260,7 +1328,7 @@ export default function IssueVotePageComponent() {
                                                 : "pointer",
                                     }}
                                 >
-                                    次へ
+                                    {isMobile ? "›" : "次へ"}
                                 </button>
                                 <button
                                     onClick={() => setCurrentPage(totalPages)}
@@ -1277,7 +1345,7 @@ export default function IssueVotePageComponent() {
                                                 : "pointer",
                                     }}
                                 >
-                                    最後 ≫
+                                    {isMobile ? "≫" : "最後 ≫"}
                                 </button>
                             </div>
                         )}

--- a/src/app/view.tsx
+++ b/src/app/view.tsx
@@ -1,8 +1,26 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import DisplayNameInput from "../components/DisplayNameInput";
 import IssueRanking from "../components/common/IssueRanking";
 import { useAuth } from "../contexts/AuthContext";
+
+// スマートフォン/タブレット判定のカスタムフック
+const useIsTablet = () => {
+    const [isTablet, setIsTablet] = useState(false);
+
+    useEffect(() => {
+        const checkIfTablet = () => {
+            setIsTablet(window.innerWidth <= 760);
+        };
+
+        checkIfTablet();
+        window.addEventListener("resize", checkIfTablet);
+
+        return () => window.removeEventListener("resize", checkIfTablet);
+    }, []);
+
+    return isTablet;
+};
 
 function View() {
     const navigate = useNavigate();
@@ -16,6 +34,8 @@ function View() {
     } = useAuth();
     const [loginError, setLoginError] = useState<string | null>(null);
     const [loggingIn, setLoggingIn] = useState(false);
+    const [isMenuOpen, setIsMenuOpen] = useState(false);
+    const isTablet = useIsTablet();
 
     const buttonStyle = {
         width: "300px",
@@ -61,6 +81,23 @@ function View() {
     const handleLogout = () => {
         logout();
     };
+
+    // メニュー外クリックで閉じる
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (
+                isMenuOpen &&
+                !(event.target as Element).closest("[data-menu]")
+            ) {
+                setIsMenuOpen(false);
+            }
+        };
+
+        document.addEventListener("mousedown", handleClickOutside);
+        return () => {
+            document.removeEventListener("mousedown", handleClickOutside);
+        };
+    }, [isMenuOpen]);
 
     if (loading) {
         return (
@@ -241,7 +278,7 @@ function View() {
                     </div>
                 )}
 
-                {isAuthenticated && voter && (
+                {isAuthenticated && voter && !isTablet && (
                     <div
                         style={{
                             position: "fixed" as const,
@@ -317,6 +354,201 @@ function View() {
                             ログアウト
                         </button>
                     </div>
+                )}
+
+                {isAuthenticated && voter && isTablet && (
+                    <>
+                        <button
+                            data-menu
+                            onClick={() => setIsMenuOpen(!isMenuOpen)}
+                            style={{
+                                position: "fixed" as const,
+                                top: "20px",
+                                right: "20px",
+                                width: "50px",
+                                height: "50px",
+                                backgroundColor: "#5FBEAA",
+                                border: "none",
+                                borderRadius: "50%",
+                                cursor: "pointer",
+                                zIndex: 1001,
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "center",
+                                boxShadow: "0 4px 12px rgba(95, 190, 170, 0.4)",
+                                transition: "all 0.3s ease",
+                            }}
+                            onMouseEnter={(e) => {
+                                (
+                                    e.target as HTMLElement
+                                ).style.backgroundColor = "#4DA894";
+                            }}
+                            onMouseLeave={(e) => {
+                                (
+                                    e.target as HTMLElement
+                                ).style.backgroundColor = "#5FBEAA";
+                            }}
+                        >
+                            <div
+                                style={{
+                                    position: "relative",
+                                    width: "20px",
+                                    height: "20px",
+                                }}
+                            >
+                                {/* サインイン状態インジケーター */}
+                                <div
+                                    style={{
+                                        position: "absolute",
+                                        top: "-2px",
+                                        right: "-2px",
+                                        width: "8px",
+                                        height: "8px",
+                                        backgroundColor: "#4ade80",
+                                        borderRadius: "50%",
+                                        border: "1px solid white",
+                                        zIndex: 1,
+                                    }}
+                                />
+                                {/* ハンバーガーアイコン */}
+                                <div
+                                    style={{
+                                        display: "flex",
+                                        flexDirection: "column",
+                                        gap: "3px",
+                                        alignItems: "center",
+                                        justifyContent: "center",
+                                    }}
+                                >
+                                    <div
+                                        style={{
+                                            width: "16px",
+                                            height: "2px",
+                                            backgroundColor: "white",
+                                            borderRadius: "1px",
+                                            transition: "all 0.3s ease",
+                                            transform: isMenuOpen
+                                                ? "rotate(45deg) translate(5px, 5px)"
+                                                : "none",
+                                        }}
+                                    />
+                                    <div
+                                        style={{
+                                            width: "16px",
+                                            height: "2px",
+                                            backgroundColor: "white",
+                                            borderRadius: "1px",
+                                            transition: "all 0.3s ease",
+                                            opacity: isMenuOpen ? 0 : 1,
+                                        }}
+                                    />
+                                    <div
+                                        style={{
+                                            width: "16px",
+                                            height: "2px",
+                                            backgroundColor: "white",
+                                            borderRadius: "1px",
+                                            transition: "all 0.3s ease",
+                                            transform: isMenuOpen
+                                                ? "rotate(-45deg) translate(5px, -5px)"
+                                                : "none",
+                                        }}
+                                    />
+                                </div>
+                            </div>
+                        </button>
+
+                        {/* メニューパネル */}
+                        {isMenuOpen && (
+                            <div
+                                data-menu
+                                style={{
+                                    position: "fixed" as const,
+                                    top: "80px",
+                                    right: "20px",
+                                    backgroundColor: "#5FBEAA",
+                                    color: "white",
+                                    border: "none",
+                                    borderRadius: "12px",
+                                    padding: "1.2rem",
+                                    boxShadow:
+                                        "0 6px 20px rgba(95, 190, 170, 0.3)",
+                                    zIndex: 1000,
+                                    minWidth: "200px",
+                                    animation: "fadeIn 0.3s ease",
+                                }}
+                            >
+                                <div
+                                    style={{
+                                        display: "flex",
+                                        alignItems: "center",
+                                        marginBottom: "1rem",
+                                        gap: "0.5rem",
+                                    }}
+                                >
+                                    <div
+                                        style={{
+                                            width: "8px",
+                                            height: "8px",
+                                            backgroundColor: "#4ade80",
+                                            borderRadius: "50%",
+                                        }}
+                                    />
+                                    <span
+                                        style={{
+                                            fontSize: "0.8em",
+                                            opacity: 0.9,
+                                        }}
+                                    >
+                                        サインイン中
+                                    </span>
+                                </div>
+                                <p
+                                    style={{
+                                        marginBottom: "1rem",
+                                        fontSize: "1em",
+                                        fontWeight: "600",
+                                        margin: "0 0 1rem 0",
+                                    }}
+                                >
+                                    {voter.display_name} さん
+                                </p>
+                                <button
+                                    onClick={() => {
+                                        handleLogout();
+                                        setIsMenuOpen(false);
+                                    }}
+                                    style={{
+                                        backgroundColor:
+                                            "rgba(255, 255, 255, 0.2)",
+                                        color: "white",
+                                        border: "1px solid rgba(255, 255, 255, 0.3)",
+                                        padding: "0.6em 1.2em",
+                                        borderRadius: "8px",
+                                        cursor: "pointer",
+                                        fontSize: "0.9em",
+                                        width: "100%",
+                                        fontWeight: "500",
+                                        transition: "all 0.2s ease",
+                                    }}
+                                    onMouseEnter={(e) => {
+                                        (
+                                            e.target as HTMLElement
+                                        ).style.backgroundColor =
+                                            "rgba(255, 255, 255, 0.3)";
+                                    }}
+                                    onMouseLeave={(e) => {
+                                        (
+                                            e.target as HTMLElement
+                                        ).style.backgroundColor =
+                                            "rgba(255, 255, 255, 0.2)";
+                                    }}
+                                >
+                                    ログアウト
+                                </button>
+                            </div>
+                        )}
+                    </>
                 )}
 
                 {needsDisplayName && (

--- a/src/app/view.tsx
+++ b/src/app/view.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import DisplayNameInput from "../components/DisplayNameInput";
 import IssueRanking from "../components/common/IssueRanking";


### PR DESCRIPTION
## Summary
• issue-voteページのスマートフォン表示最適化（480px以下）
• ログイン状態インジケータのレスポンシブ対応（760px以下でハンバーガーメニュー）
• ページネーションとボタンのモバイル最適化

## 主な変更点

### 1. issue-voteページのスマートフォン最適化
- **ページネーションボタンの改善**
  - 表示ページ数を5個→3個に削減（480px以下）
  - ボタンテキストを短縮（「≪ 最初」→「≪」、「前へ」→「‹」等）
  - 最小タップサイズ44px×44pxを確保
  - flexWrapで複数行レイアウトに対応

- **投票ボタンの最適化**
  - 「👍 Good」→「👍」、「👎 Bad」→「👎」に短縮
  - フォントサイズとパディングをコンパクトに調整
  - スマートフォン時は中央寄せレイアウト

- **GitHubリンクボタンの最適化**
  - 「🔗 GitHubで開く」→「GitHub」に短縮
  - コンパクトなサイズに調整

- **レイアウト全体の改善**
  - ボタンエリアを480px以下で縦並びに変更
  - 各ボタンが画面幅に適切にフィット

### 2. ログイン状態インジケータのレスポンシブ対応
- **デスクトップ表示（760px超）**
  - 従来通りの右上固定パネル表示を維持

- **タブレット/スマートフォン表示（760px以下）**
  - 丸い背景のハンバーガーボタンに変更
  - ボタン右上にサインイン状態インジケーター（緑の丸）を配置
  - クリック時にXアイコンに変形するスムーズなアニメーション

- **ハンバーガーメニューの機能**
  - ボタンクリックでメニューパネルを表示/非表示
  - メニュー外クリックで自動的に閉じる機能
  - ログアウト時もメニューを自動で閉じる
  - fadeInアニメーション効果

### 3. レスポンシブ対応の技術実装
- `useIsMobile`フック（480px以下判定）を issue-vote ページに追加
- `useIsTablet`フック（760px以下判定）を view ページに追加
- リサイズイベントに対応した動的な画面サイズ判定

## Test plan
- [ ] スマートフォン（480px以下）でissue-voteページのページネーションが正常に動作することを確認
- [ ] スマートフォンで投票ボタンとGitHubリンクが適切なサイズで表示されることを確認
- [ ] タブレット（760px以下）でハンバーガーメニューが正常に動作することを確認
- [ ] ハンバーガーメニューのアニメーションが滑らかに動作することを確認
- [ ] メニュー外クリックで正常に閉じることを確認
- [ ] デスクトップ表示で従来通りの表示が維持されることを確認
- [ ] 画面サイズ変更時にレスポンシブ表示が正常に切り替わることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>