### PR TITLE
fix: RPC依存を削除してデプロイ安定性を向上

### DIFF
--- a/src/components/common/IssueRanking.tsx
+++ b/src/components/common/IssueRanking.tsx
@@ -138,107 +138,66 @@ export default function IssueRanking({ maxItems = 5 }: IssueRankingProps) {
             setLoading(true);
             setError(null);
 
-            // Supabase上でスコア計算とソートを実行（正確なランキング）
-            const { data: rankedIssuesData, error: issuesError } =
-                await supabase.rpc("get_top_ranked_issues", {
-                    limit_count: maxItems,
+            // クライアント側でランキング計算（安定版）
+            const { data: allIssues, error: issuesError } = await supabase
+                .from("github_issues")
+                .select("*");
+
+            if (issuesError) throw issuesError;
+
+            const { data: allVotes, error: votesError } = await supabase
+                .from("issue_votes")
+                .select("issue_id, vote_type");
+
+            if (votesError) throw votesError;
+
+            const voteCountsMap: Record<string, { good: number; bad: number }> =
+                {};
+
+            allVotes?.forEach(
+                (vote: {
+                    issue_id: string | number;
+                    vote_type: string;
+                }) => {
+                    if (!voteCountsMap[vote.issue_id]) {
+                        voteCountsMap[vote.issue_id] = { good: 0, bad: 0 };
+                    }
+                    if (vote.vote_type === "good") {
+                        voteCountsMap[vote.issue_id].good++;
+                    } else if (vote.vote_type === "bad") {
+                        voteCountsMap[vote.issue_id].bad++;
+                    }
+                },
+            );
+
+            const issuesWithVotes: IssueWithVotes[] = [];
+            for (const issue of allIssues || []) {
+                const voteCounts = voteCountsMap[issue.issue_id] || {
+                    good: 0,
+                    bad: 0,
+                };
+
+                const totalGoodCount =
+                    voteCounts.good + (issue.plus_one_count || 0);
+                const totalBadCount =
+                    voteCounts.bad + (issue.minus_one_count || 0);
+                const score = totalGoodCount - totalBadCount;
+
+                issuesWithVotes.push({
+                    issue,
+                    goodVotes: voteCounts.good,
+                    badVotes: voteCounts.bad,
+                    totalGoodCount,
+                    totalBadCount,
+                    score,
                 });
-
-            if (issuesError) {
-                // RPCが利用できない場合はフォールバック方式
-                console.warn(
-                    "RPC not available, using fallback method:",
-                    issuesError,
-                );
-
-                // 全issueを取得してクライアント側でランキング計算
-                const { data: allIssues, error: fallbackError } = await supabase
-                    .from("github_issues")
-                    .select("*");
-
-                if (fallbackError) throw fallbackError;
-
-                const { data: allVotes, error: votesError } = await supabase
-                    .from("issue_votes")
-                    .select("issue_id, vote_type");
-
-                if (votesError) throw votesError;
-
-                const voteCountsMap: Record<
-                    string,
-                    { good: number; bad: number }
-                > = {};
-
-                allVotes?.forEach(
-                    (vote: {
-                        issue_id: string | number;
-                        vote_type: string;
-                    }) => {
-                        if (!voteCountsMap[vote.issue_id]) {
-                            voteCountsMap[vote.issue_id] = { good: 0, bad: 0 };
-                        }
-                        if (vote.vote_type === "good") {
-                            voteCountsMap[vote.issue_id].good++;
-                        } else if (vote.vote_type === "bad") {
-                            voteCountsMap[vote.issue_id].bad++;
-                        }
-                    },
-                );
-
-                const issuesWithVotes: IssueWithVotes[] = [];
-                for (const issue of allIssues || []) {
-                    const voteCounts = voteCountsMap[issue.issue_id] || {
-                        good: 0,
-                        bad: 0,
-                    };
-
-                    const totalGoodCount =
-                        voteCounts.good + (issue.plus_one_count || 0);
-                    const totalBadCount =
-                        voteCounts.bad + (issue.minus_one_count || 0);
-                    const score = totalGoodCount - totalBadCount;
-
-                    issuesWithVotes.push({
-                        issue,
-                        goodVotes: voteCounts.good,
-                        badVotes: voteCounts.bad,
-                        totalGoodCount,
-                        totalBadCount,
-                        score,
-                    });
-                }
-
-                const ranked = issuesWithVotes
-                    .sort((a, b) => b.score - a.score)
-                    .slice(0, maxItems);
-
-                setRankedIssues(ranked);
-            } else {
-                // RPC結果を使用
-                const issuesWithVotes: IssueWithVotes[] = rankedIssuesData.map(
-                    (item: any) => ({
-                        issue: {
-                            issue_id: item.issue_id,
-                            title: item.title,
-                            body: item.body,
-                            github_issue_number: item.github_issue_number,
-                            repository_owner: item.repository_owner,
-                            repository_name: item.repository_name,
-                            created_at: item.created_at,
-                            plus_one_count: item.plus_one_count,
-                            minus_one_count: item.minus_one_count,
-                            branch_name: item.branch_name,
-                        },
-                        goodVotes: item.good_votes || 0,
-                        badVotes: item.bad_votes || 0,
-                        totalGoodCount: item.total_good_count || 0,
-                        totalBadCount: item.total_bad_count || 0,
-                        score: item.score || 0,
-                    }),
-                );
-
-                setRankedIssues(issuesWithVotes);
             }
+
+            const ranked = issuesWithVotes
+                .sort((a, b) => b.score - a.score)
+                .slice(0, maxItems);
+
+            setRankedIssues(ranked);
         } catch (err) {
             console.error("Error fetching ranked issues:", err);
             setError("ランキングの取得に失敗しました");


### PR DESCRIPTION
## Summary
- PostgreSQL RPC関数の依存を削除してデプロイエラーを解決
- クライアント側で全Issueを対象とした正確なランキング計算に変更
- ブラウザキャッシュ問題の修正も含む

## 主な修正内容

### RPC依存削除
- `get_top_ranked_issues()` RPC関数の呼び出しを削除
- クライアント側での完全なランキング計算に変更
- デプロイ時のPostgreSQL関数依存エラーを回避

### AuthContext改善（前回PRから継続）
- 認証初期化に5秒タイムアウトを追加
- 古いSupabaseキャッシュの自動クリア機能
- メモリリーク防止のクリーンアップ処理

### IssueRanking安定化
- 全Issueデータを取得して正確なランキング計算
- 再試行ロジックとエラーハンドリングの強化
- 60秒間隔での定期更新

## Test plan
- [ ] Vercelデプロイが成功する
- [ ] ランキング表示が正常に動作する
- [ ] ブラウザキャッシュ問題が解決している
- [ ] 認証フローが安定している

🤖 Generated with [Claude Code](https://claude.ai/code)