### PR TITLE
fix: RPC関数の型定義を実際のスキーマに合わせて修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,21 +127,21 @@ npm run sync-prs
 ```sql
 CREATE OR REPLACE FUNCTION get_top_ranked_issues(limit_count INT DEFAULT 5)
 RETURNS TABLE (
-    issue_id TEXT,
+    issue_id UUID,
     title TEXT,
     body TEXT,
-    github_issue_number BIGINT,
+    github_issue_number INT,
     repository_owner TEXT,
     repository_name TEXT,
     created_at TIMESTAMPTZ,
     plus_one_count INT,
     minus_one_count INT,
     branch_name TEXT,
-    good_votes BIGINT,
-    bad_votes BIGINT,
-    total_good_count BIGINT,
-    total_bad_count BIGINT,
-    score BIGINT
+    good_votes INT,
+    bad_votes INT,
+    total_good_count INT,
+    total_bad_count INT,
+    score INT
 ) 
 LANGUAGE plpgsql
 AS $$
@@ -150,8 +150,8 @@ BEGIN
     WITH vote_counts AS (
         SELECT 
             iv.issue_id,
-            COALESCE(SUM(CASE WHEN iv.vote_type = 'good' THEN 1 ELSE 0 END), 0) as good_votes,
-            COALESCE(SUM(CASE WHEN iv.vote_type = 'bad' THEN 1 ELSE 0 END), 0) as bad_votes
+            COALESCE(SUM(CASE WHEN iv.vote_type = 'good' THEN 1 ELSE 0 END), 0)::INT as good_votes,
+            COALESCE(SUM(CASE WHEN iv.vote_type = 'bad' THEN 1 ELSE 0 END), 0)::INT as bad_votes
         FROM issue_votes iv
         GROUP BY iv.issue_id
     )
@@ -178,6 +178,9 @@ BEGIN
     LIMIT limit_count;
 END;
 $$;
+
+-- 権限付与
+GRANT EXECUTE ON FUNCTION get_top_ranked_issues TO anon, authenticated;
 ```
 
 この関数により、全てのIssueを対象とした正確なランキングを効率的に取得できます。関数が利用できない場合は、自動的にクライアント側での計算にフォールバックします。


### PR DESCRIPTION
## 概要
README.mdのRPC関数定義で型不一致エラーが発生していた問題を修正しました。実際のデータベーススキーマと一致するよう型定義を更新し、400エラーを解決します。

## 問題
Supabase SQL EditorでRPC関数を実行時に以下のエラーが発生：
```
ERROR: 42804: structure of query does not match function result type
DETAIL: Returned type uuid does not match expected type text in column 1.
DETAIL: Returned type integer does not match expected type bigint in column 4.
```

## 修正内容

### 🔧 型定義の修正
- **issue_id**: `TEXT` → `UUID`（実際のテーブル構造に合わせる）
- **数値型統一**: `BIGINT` → `INT`（PostgreSQLの厳密な型チェック対応）
- **github_issue_number**: `BIGINT` → `INT`
- **good_votes, bad_votes**: `BIGINT` → `INT`
- **total_good_count, total_bad_count**: `BIGINT` → `INT`
- **score**: `BIGINT` → `INT`

### 🎯 明示的型変換の追加
- **SUM結果のキャスト**: `::INT`を追加して型を明示的に変換
- **型安全性**: PostgreSQLの厳密な型チェックに対応

### 🔐 権限設定の追加
- **GRANT EXECUTE文**: 関数実行権限を明示的に付与
- **anon, authenticated**: 必要なロールに権限付与

## 実際のテーブル構造
- `github_issues.issue_id`: UUID型
- `github_issues.github_issue_number`: INTEGER型
- `issue_votes.issue_id`: UUID型（外部キー）

## テスト結果
修正後のSQL関数を実行してエラーが解消されることを確認：
```sql
SELECT * FROM get_top_ranked_issues(5);
```

## 影響範囲
- **README.md**: RPC関数定義の型修正
- **ランキング機能**: RPC関数が正常動作するようになり、パフォーマンス向上
- **フォールバック**: 型エラーが解消されるため、RPC優先実行が可能

## 後方互換性
- 既存のクライアント側ランキング計算は影響なし
- RPC関数が利用できない環境でも自動フォールバック継続

🤖 Generated with [Claude Code](https://claude.ai/code)