### PR TITLE
Fix mobile pagination button display

### DIFF
--- a/src/app/issues/page.tsx
+++ b/src/app/issues/page.tsx
@@ -629,6 +629,7 @@ export default function IssuesPageComponent() {
                                         searchTerm.trim().length === 0
                                             ? 0.6
                                             : 1,
+                                    width: isExtraSmallMobile ? "100%" : "auto",
                                 }}
                                 onMouseEnter={(e) => {
                                     if (
@@ -670,6 +671,9 @@ export default function IssuesPageComponent() {
                                         cursor: "pointer",
                                         transition: "all 0.2s ease",
                                         whiteSpace: "nowrap",
+                                        width: isExtraSmallMobile
+                                            ? "100%"
+                                            : "auto",
                                     }}
                                     onMouseEnter={(e) => {
                                         e.currentTarget.style.backgroundColor =

--- a/src/app/issues/page.tsx
+++ b/src/app/issues/page.tsx
@@ -487,6 +487,9 @@ export default function IssuesPageComponent() {
         margin: "0 0.25rem",
     };
 
+    const isMobile = useIsMobile();
+    const isExtraSmallMobile = useIsExtraSmallMobile();
+
     const paginationStyle: React.CSSProperties = {
         display: "flex",
         justifyContent: "center",
@@ -514,9 +517,6 @@ export default function IssuesPageComponent() {
         color: "white",
         borderColor: "#5FBEAA",
     };
-
-    const isMobile = useIsMobile();
-    const isExtraSmallMobile = useIsExtraSmallMobile();
 
     return (
         <div style={isMobile ? mobileContainerStyle : containerStyle}>

--- a/src/app/issues/page.tsx
+++ b/src/app/issues/page.tsx
@@ -491,18 +491,21 @@ export default function IssuesPageComponent() {
         display: "flex",
         justifyContent: "center",
         alignItems: "center",
-        gap: "0.5rem",
+        gap: isExtraSmallMobile ? "0.25rem" : "0.5rem",
         marginTop: "2rem",
+        flexWrap: "wrap",
     };
 
     const pageButtonStyle: React.CSSProperties = {
         backgroundColor: "#f8f9fa",
         color: "#333",
         border: "1px solid #dee2e6",
-        padding: "0.5rem 0.75rem",
+        padding: isExtraSmallMobile ? "0.4rem 0.5rem" : "0.5rem 0.75rem",
         borderRadius: "4px",
         cursor: "pointer",
-        fontSize: "0.9rem",
+        fontSize: isExtraSmallMobile ? "0.8rem" : "0.9rem",
+        minWidth: isExtraSmallMobile ? "auto" : "unset",
+        whiteSpace: "nowrap",
     };
 
     const activePageButtonStyle: React.CSSProperties = {
@@ -734,7 +737,7 @@ export default function IssuesPageComponent() {
                                 disabled={currentPage === 1}
                                 style={pageButtonStyle}
                             >
-                                ≪ 最初
+                                {isExtraSmallMobile ? "≪" : "≪ 最初"}
                             </button>
                             <button
                                 onClick={() =>
@@ -743,7 +746,7 @@ export default function IssuesPageComponent() {
                                 disabled={currentPage === 1}
                                 style={pageButtonStyle}
                             >
-                                前へ
+                                {isExtraSmallMobile ? "←" : "前へ"}
                             </button>
 
                             {Array.from(
@@ -783,14 +786,14 @@ export default function IssuesPageComponent() {
                                 disabled={currentPage === totalPages}
                                 style={pageButtonStyle}
                             >
-                                次へ
+                                {isExtraSmallMobile ? "→" : "次へ"}
                             </button>
                             <button
                                 onClick={() => setCurrentPage(totalPages)}
                                 disabled={currentPage === totalPages}
                                 style={pageButtonStyle}
                             >
-                                最後 ≫
+                                {isExtraSmallMobile ? "≫" : "最後 ≫"}
                             </button>
                         </div>
                     )}
@@ -1269,7 +1272,7 @@ export default function IssuesPageComponent() {
                                     disabled={currentPage === 1}
                                     style={pageButtonStyle}
                                 >
-                                    ≪ 最初
+                                    {isExtraSmallMobile ? "≪" : "≪ 最初"}
                                 </button>
                                 <button
                                     onClick={() =>
@@ -1280,7 +1283,7 @@ export default function IssuesPageComponent() {
                                     disabled={currentPage === 1}
                                     style={pageButtonStyle}
                                 >
-                                    前へ
+                                    {isExtraSmallMobile ? "←" : "前へ"}
                                 </button>
 
                                 {Array.from(
@@ -1323,14 +1326,14 @@ export default function IssuesPageComponent() {
                                     disabled={currentPage === totalPages}
                                     style={pageButtonStyle}
                                 >
-                                    次へ
+                                    {isExtraSmallMobile ? "→" : "次へ"}
                                 </button>
                                 <button
                                     onClick={() => setCurrentPage(totalPages)}
                                     disabled={currentPage === totalPages}
                                     style={pageButtonStyle}
                                 >
-                                    最後 ≫
+                                    {isExtraSmallMobile ? "≫" : "最後 ≫"}
                                 </button>
                             </div>
                         )}

--- a/src/app/view.tsx
+++ b/src/app/view.tsx
@@ -287,6 +287,7 @@ function View() {
                                     fontSize: "14px",
                                     fontWeight: "500",
                                     color: "#1f1f1f",
+                                    textShadow: "none",
                                 }}
                             >
                                 Googleでログイン


### PR DESCRIPTION
## Summary
- モバイルデバイス（特に極小画面）でのページネーションボタンの表示問題を修正
- ボタンがはみ出す問題を解決し、モバイルでの操作性を向上

## 変更内容
- 極小画面（380px以下）でのページネーションボタンサイズを縮小（padding: 0.4rem 0.5rem）
- ボタンテキストを矢印記号に変更（≪, ←, →, ≫）
- flexWrap: "wrap"を追加してボタンが折り返すように調整
- ボタン間の間隔を調整（極小画面では0.25rem）

## 改善内容
- iPhone SafariやAndroid Chromeでのページネーションボタンのはみ出しを解決
- モバイルデバイスでのユーザビリティを向上
- 極小画面でのボタンサイズ最適化

🤖 Generated with [Claude Code](https://claude.ai/code)