### PR TITLE
Reduce auth initialization timeout from 5s to 3s

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -78,7 +78,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                     console.warn("キャッシュクリアに失敗:", error);
                 }
 
-                // 5秒タイムアウトを設定
+                // 3秒タイムアウトを設定
                 authTimeout = setTimeout(() => {
                     if (isMounted && !isTimedOut) {
                         console.warn("認証初期化がタイムアウトしました");
@@ -89,7 +89,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
                         setNeedsDisplayName(false);
                         setLoading(false);
                     }
-                }, 5000);
+                }, 3000);
 
                 // タイムアウト前に完了した場合の処理
                 if (isTimedOut) return;


### PR DESCRIPTION
## Summary
- 認証初期化のタイムアウト時間を5秒から3秒に短縮
- ユーザー体験向上のため応答性を改善

## 変更内容
- `AuthContext.tsx`の認証初期化タイムアウトを3000ms（3秒）に変更
- コメントも「3秒タイムアウト」に更新

## 効果
- より早くアプリケーションが利用可能になる
- 認証が遅い場合の待機時間短縮
- ユーザー体験の向上

## リスク評価
- 3秒は一般的なネットワーク環境で十分な時間
- タイムアウト後も認証なし状態でアプリ継続使用可能
- 必要に応じて再ログインで認証可能

🤖 Generated with [Claude Code](https://claude.ai/code)