### PR TITLE
feat: スマートフォン向けスクロールトップボタンを追加

### DIFF
--- a/src/app/issue-vote/page.tsx
+++ b/src/app/issue-vote/page.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import NetworkTimeoutOverlay from "../../components/common/NetworkTimeoutOverlay";
+import ScrollToTopButton from "../../components/common/ScrollToTopButton";
 import { useAuth } from "../../contexts/AuthContext";
 import { supabase } from "../../lib/supabaseClient";
 import type { Tables } from "../../types/supabase";
@@ -1726,6 +1727,9 @@ export default function IssueVotePageComponent() {
                 onClose={handleTimeoutClose}
                 message="Issueデータの取得に時間がかかっています"
             />
+
+            {/* スクロールトップボタン */}
+            <ScrollToTopButton isMobile={isMobile} threshold={400} />
         </div>
     );
 }

--- a/src/app/issues/page.tsx
+++ b/src/app/issues/page.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef } from "react";
 import NetworkTimeoutOverlay from "../../components/common/NetworkTimeoutOverlay";
+import ScrollToTopButton from "../../components/common/ScrollToTopButton";
 import { useAuth } from "../../contexts/AuthContext";
 import { supabase } from "../../lib/supabaseClient";
 import type { Tables } from "../../types/supabase";
@@ -1454,6 +1455,9 @@ export default function IssuesPageComponent() {
                 onClose={handleTimeoutClose}
                 message="Issue一覧の取得に時間がかかっています"
             />
+
+            {/* スクロールトップボタン */}
+            <ScrollToTopButton isMobile={isMobile} threshold={400} />
         </div>
     );
 }

--- a/src/components/common/ScrollToTopButton.tsx
+++ b/src/components/common/ScrollToTopButton.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from "react";
+
+interface ScrollToTopButtonProps {
+    threshold?: number;
+    isMobile?: boolean;
+}
+
+export default function ScrollToTopButton({
+    threshold = 300,
+    isMobile = false,
+}: ScrollToTopButtonProps) {
+    const [isVisible, setIsVisible] = useState(false);
+
+    useEffect(() => {
+        const toggleVisibility = () => {
+            if (window.pageYOffset > threshold) {
+                setIsVisible(true);
+            } else {
+                setIsVisible(false);
+            }
+        };
+
+        window.addEventListener("scroll", toggleVisibility);
+
+        return () => {
+            window.removeEventListener("scroll", toggleVisibility);
+        };
+    }, [threshold]);
+
+    const scrollToTop = () => {
+        window.scrollTo({
+            top: 0,
+            behavior: "smooth",
+        });
+    };
+
+    if (!isVisible) {
+        return null;
+    }
+
+    return (
+        <button
+            onClick={scrollToTop}
+            style={{
+                position: "fixed",
+                bottom: isMobile ? "20px" : "30px",
+                right: isMobile ? "20px" : "30px",
+                width: isMobile ? "50px" : "60px",
+                height: isMobile ? "50px" : "60px",
+                borderRadius: "50%",
+                backgroundColor: "#5FBEAA",
+                color: "white",
+                border: "none",
+                cursor: "pointer",
+                boxShadow: "0 4px 12px rgba(0, 0, 0, 0.15)",
+                zIndex: 1000,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                fontSize: isMobile ? "18px" : "20px",
+                fontWeight: "bold",
+                transition: "all 0.3s ease",
+                animation: "fadeInUp 0.3s ease-out",
+            }}
+            onMouseEnter={(e) => {
+                if (!isMobile) {
+                    e.currentTarget.style.backgroundColor = "#4DA894";
+                    e.currentTarget.style.transform = "translateY(-2px)";
+                    e.currentTarget.style.boxShadow =
+                        "0 6px 16px rgba(0, 0, 0, 0.2)";
+                }
+            }}
+            onMouseLeave={(e) => {
+                if (!isMobile) {
+                    e.currentTarget.style.backgroundColor = "#5FBEAA";
+                    e.currentTarget.style.transform = "translateY(0)";
+                    e.currentTarget.style.boxShadow =
+                        "0 4px 12px rgba(0, 0, 0, 0.15)";
+                }
+            }}
+            onTouchStart={(e) => {
+                if (isMobile) {
+                    e.currentTarget.style.backgroundColor = "#4DA894";
+                    e.currentTarget.style.transform = "scale(0.95)";
+                }
+            }}
+            onTouchEnd={(e) => {
+                if (isMobile) {
+                    e.currentTarget.style.backgroundColor = "#5FBEAA";
+                    e.currentTarget.style.transform = "scale(1)";
+                }
+            }}
+            aria-label="ページトップへ戻る"
+            title="ページトップへ戻る"
+        >
+            ↑
+        </button>
+    );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -115,3 +115,14 @@ button:focus-visible {
         transform: scale(1);
     }
 }
+
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}


### PR DESCRIPTION
## Summary
- 長いページでのユーザビリティ向上のため、右下にスクロールトップボタンを実装
- スマートフォンとデスクトップ両方に最適化されたレスポンシブデザイン
- 美しいアニメーションとアクセシビリティに配慮

## 変更内容
- **ScrollToTopButton コンポーネント**: 共通の再利用可能なスクロールトップボタンを新規作成
- **issue-voteページ**: スクロールトップボタンを追加（400px以降に表示）
- **issuesページ**: スクロールトップボタンを追加（400px以降に表示）
- **CSS アニメーション**: fadeInUp キーフレーム追加でスムーズな出現

## 機能の特徴
- 📱 スマートフォン対応：50px円形ボタン、タッチ操作に最適化
- 🖥️ デスクトップ対応：60px円形ボタン、ホバーエフェクト付き
- ⚡ パフォーマンス：スクロールイベントリスナーの適切な管理
- ♿ アクセシビリティ：aria-label、title属性対応
- 🎨 美しいUI：スムーズアニメーション、シャドウエフェクト

## Test plan
- [ ] issue-voteページでスクロールダウン後にボタンが表示されるか確認
- [ ] issuesページでスクロールダウン後にボタンが表示されるか確認
- [ ] ボタンクリックでページトップにスムーズスクロールするか確認
- [ ] スマートフォンでタッチ操作が正常に動作するか確認
- [ ] デスクトップでホバーエフェクトが正常に動作するか確認

🤖 Generated with [Claude Code](https://claude.ai/code)