### PR TITLE
fix: issuesページの改行が不自然になる問題を修正

### DIFF
--- a/src/app/issues/page.tsx
+++ b/src/app/issues/page.tsx
@@ -1427,6 +1427,9 @@ export default function IssuesPageComponent() {
                                                         WebkitLineClamp: 3,
                                                         WebkitBoxOrient:
                                                             "vertical" as const,
+                                                        overflowWrap:
+                                                            "break-word",
+                                                        wordBreak: "break-word",
                                                     }}
                                                 >
                                                     {issue.body}


### PR DESCRIPTION
issueの本文で長い文字列がコンテナの幅を超えた際に、テキストが不自然に改行される問題を修正しました。

 と  をスタイルに追加することで、長い単語やURLが適切に折り返されるようにしました。