### PR TITLE
feat: Vercelの公開を制御するGitHub Actionsを追加

### DIFF
--- a/.github/workflows/vercel-control.yml
+++ b/.github/workflows/vercel-control.yml
@@ -1,0 +1,40 @@
+name: Vercel Project Control
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: '実行するアクションを選択してください'
+        required: true
+        type: choice
+        options:
+          - pause
+          - unpause
+        default: 'pause'
+
+jobs:
+  control-vercel-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pause Vercel Project
+        if: github.event.inputs.action == 'pause'
+        run: |
+          curl -X PATCH "https://api.vercel.com/v9/projects/${{ secrets.VERCEL_PROJECT_ID }}" \
+               -H "Authorization: Bearer ${{ secrets.VERCEL_TOKEN }}" \
+               -H "Content-Type: application/json" \
+               -d '{ "paused": true }'
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Unpause Vercel Project
+        if: github.event.inputs.action == 'unpause'
+        run: |
+          curl -X PATCH "https://api.vercel.com/v9/projects/${{ secrets.VERCEL_PROJECT_ID }}" \
+               -H "Authorization: Bearer ${{ secrets.VERCEL_TOKEN }}" \
+               -H "Content-Type: application/json" \
+               -d '{ "paused": false }'
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+


### PR DESCRIPTION
Vercelプロジェクトの公開を一時停止（Pause）および再開（Unpause）するためのGitHub Actionsワークフローを追加しました。

このワークフローは手動でトリガーでき、VercelのAPIを介してプロジェクトの状態を安全に切り替えることができます。