### PR TITLE
fix(actions): Vercelプロジェクト制御ワークフローを修正

### DIFF
--- a/.github/workflows/vercel-control.yml
+++ b/.github/workflows/vercel-control.yml
@@ -22,7 +22,7 @@ jobs:
           curl -X PATCH "https://api.vercel.com/v9/projects/${{ secrets.VERCEL_PROJECT_ID }}" \
                -H "Authorization: Bearer ${{ secrets.VERCEL_TOKEN }}" \
                -H "Content-Type: application/json" \
-               -d '{ "paused": true }'
+               -d '{ "commandForIgnoringBuildStep": "false" }'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
@@ -33,7 +33,7 @@ jobs:
           curl -X PATCH "https://api.vercel.com/v9/projects/${{ secrets.VERCEL_PROJECT_ID }}" \
                -H "Authorization: Bearer ${{ secrets.VERCEL_TOKEN }}" \
                -H "Content-Type: application/json" \
-               -d '{ "paused": false }'
+               -d '{ "commandForIgnoringBuildStep": null }'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
Vercel APIの仕様に合わせて、プロジェクトのビルドを一時停止・再開する方法を修正しました。

-  プロパティの代わりに  を使用します。
- Pause時は  を設定してビルドを常に無視させます。
- Unpause時は  を設定してビルドを通常通り実行させます。

これにより、以前報告されたAPIエラーが解消されます。